### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,7 +425,7 @@
         </div>
         <div class="clearfix"></div>
       </div>
-      <p class="text-center">© 2015 SUSE LLC. <span lang="en">All Rights Reserved.</span></p>
+      <p class="text-center">© 2015 SUSE LLC. <span lang="en">All Rights Reserved. </span><a href="https://de.opensuse.org/Terms_of_site">Legal Information</a></p>
     </div>
   </footer>
   <!-- Piwik -->


### PR DESCRIPTION
Imprint/Impressum is a legal requirement (German TMG) and we need to make sure there is a link to the relevant legal information directly from the homepage.

Note that only the german wiki has the information. There is an english Terms_of_site page but it doesn't contain the same information as the german one. It may make sense to update the english wiki too.

This is just a suggestion, but the link needs to be on the front page.