### PR TITLE
Kiwi URL change to a working one

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,12 +215,12 @@
           </div>
           <div class="media wow slideInLeft">
             <div class="media-left">
-              <a href="http://opensuse.github.io/kiwi/" target="_blank">
+              <a href="http://suse.github.io/kiwi/" target="_blank">
                 <img class="media-object" src="build/images/tools/kiwi.svg" alt="Kiwi">
               </a>
             </div>
             <div class="media-body">
-              <a href="http://opensuse.github.io/kiwi/" target="_blank">
+              <a href="http://suse.github.io/kiwi/" target="_blank">
                 <h4 class="media-heading opensuse-blue strong-title">
                   Kiwi
                   <small>


### PR DESCRIPTION
Hello,

I wanted to have some more information about KIWI and clicked on the link. The link gave me a 404.
Maybe I've changed it to the wrong URL but it is in my opinion better to have a working link than a 404.

Cheers, Paul