### PR TITLE
Remove Asturian and Korean from language list

### DIFF
--- a/assets/js/opensuse-theme.js
+++ b/assets/js/opensuse-theme.js
@@ -256,7 +256,6 @@ function backToMainPageOs (os) {
 var lang = new Lang('en');
 //languages setup - please list here all new language packs
 window.lang.dynamic('ar', 'assets/js/langpack/ar.json');
-window.lang.dynamic('ast', 'assets/js/langpack/ast.json');
 window.lang.dynamic('ca', 'assets/js/langpack/ca.json');
 window.lang.dynamic('cs', 'assets/js/langpack/cs.json');
 window.lang.dynamic('da', 'assets/js/langpack/da.json');
@@ -270,7 +269,6 @@ window.lang.dynamic('hy', 'assets/js/langpack/hy.json');
 window.lang.dynamic('id', 'assets/js/langpack/id.json');
 window.lang.dynamic('it', 'assets/js/langpack/it.json');
 window.lang.dynamic('ja', 'assets/js/langpack/ja.json');
-window.lang.dynamic('ko', 'assets/js/langpack/ko.json');
 window.lang.dynamic('lt', 'assets/js/langpack/lt.json');
 window.lang.dynamic('nl', 'assets/js/langpack/nl.json');
 window.lang.dynamic('nn', 'assets/js/langpack/nn.json');

--- a/index.html
+++ b/index.html
@@ -396,7 +396,6 @@
             <ul class="dropdown-menu languages" aria-labelledby="dropdownMenu1">
               <li><a href="#" class="change-language" data-language-value="ar">Arabic</a></li>
               <li><a href="#" class="change-language" data-language-value="hy">Armenian</a></li>
-              <li><a href="#" class="change-language" data-language-value="ast">Asturian</a></li>
               <li><a href="#" class="change-language" data-language-value="ca">Catalan</a></li>
               <li><a href="#" class="change-language" data-language-value="cs">Czech</a></li>
               <li><a href="#" class="change-language" data-language-value="da">Danish</a></li>
@@ -410,7 +409,6 @@
               <li><a href="#" class="change-language" data-language-value="id">Indonesian</a></li>
               <li><a href="#" class="change-language" data-language-value="it">Italian</a></li>
               <li><a href="#" class="change-language" data-language-value="ja">Japanese</a></li>
-              <li><a href="#" class="change-language" data-language-value="ko">Korean</a></li>
               <li><a href="#" class="change-language" data-language-value="lt">Lietuvių</a></li>
               <li><a href="#" class="change-language" data-language-value="nl">Dutch</a></li>
               <li><a href="#" class="change-language" data-language-value="nn">Norwegian Nynorsk</a></li>


### PR DESCRIPTION
Asturian is only translated 48%.
Korean is only translated 38%.
The rest is fine translated and should be kept.