### PR TITLE
#73: require fonts with extended characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 po/*.po*
 node_modules/
+build/

--- a/BUILD.CMD
+++ b/BUILD.CMD
@@ -1,0 +1,8 @@
+CALL "C:\Program Files\nodejs\nodevars.bat"
+ECHO ON
+REM GOTO RUN
+CALL NPM install gulp gulp-concat gulp-uglify gulp-rename gulp-strip-debug gulp-less ^
+ gulp-clean-css gulp-imagemin gulp-cache gulp-shell
+:RUN
+CALL NODE_MODULES\.BIN\GULP
+PAUSE

--- a/README.md
+++ b/README.md
@@ -27,13 +27,23 @@ GULP is used to run automatic tasks to preprocess CSS (from less), compress imag
 # zypper in 'rubygem(nokogiri)' 'rubygem(gettext)' npm gettext-tools
 $ po/update_po.rb
 $ npm update
-$ npm install gulp
+$ npm install \
+ gulp \
+ gulp-concat \
+ gulp-uglify \
+ gulp-rename \
+ gulp-strip-debug \
+ gulp-less \
+ gulp-clean-css \
+ gulp-imagemin \
+ gulp-cache \
+ gulp-shell
 $ node_modules/.bin/gulp
 </pre>
 <small>More info about <a href="http://gulpjs.com/" target="_blank">gulp here</a></small>
 
-Gulp will give the final touch in the code so then you only need to open the project in your browser
-http://localhost:8000
+Gulp will give the final touch in the code so then you only need to open [the project](http://localhost:8000) in your browser
+(that requires python; if you do not have python, just open the file <U >index.html</U>).
 Test your language works well. To make sure there is no variable without translation, open up the web inspector of your browser and check if there is error message in the console, if not, you have done an Excellent job!
 So, open a new Pull Request in github, we will double check everything is fine, and then Merge your contribution!
 

--- a/assets/css/openSUSE.less
+++ b/assets/css/openSUSE.less
@@ -1,5 +1,5 @@
 //dependencies
-@import url(//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600);
+@import (css) url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600&subset=latin-ext');
 @import "vendor/bootstrap/bootstrap.less";
 
 //Opensuse theme

--- a/assets/css/opensuse-countdown.less
+++ b/assets/css/opensuse-countdown.less
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700);
+@import (css) url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700&subset=latin-ext');
 
 .opensuse-countdown {
   padding-top: 30px;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ gulp.task('scripts', function() {
 // Preprocess CSS
 var less = require('gulp-less');
 var path = require('path');
-var minifyCss = require('gulp-minify-css');
+var minifyCss = require('gulp-clean-css');
 
 gulp.task('less', function () {
   return gulp.src(assets + 'css/openSUSE.less')
@@ -46,7 +46,7 @@ gulp.task('less', function () {
       paths: [ path.join(__dirname, 'less', 'includes') ]
     }))
     .pipe(rename({suffix: '.min'}))
-    .pipe(minifyCss())
+    .pipe(minifyCss({inline: false}))
     .pipe(gulp.dest(destination + 'css'));
 });
 


### PR DESCRIPTION
Fix #73

1. replace minify-css with clean-css
2. declare font face imports as css
3. prevent clean-css from expanding imports
4. request fonts with extended characters
5. update build instructions
6. add BUILD.CMD