### PR TITLE
Fixes Kiwi link to no longer show 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,12 +216,12 @@
           </div>
           <div class="media wow slideInLeft">
             <div class="media-left">
-              <a href="http://suse.github.io/kiwi/" target="_blank">
+              <a href="http://opensuse.github.io/kiwi/" target="_blank">
                 <img class="media-object" src="build/images/tools/kiwi.svg" alt="Kiwi">
               </a>
             </div>
             <div class="media-body">
-              <a href="http://suse.github.io/kiwi/" target="_blank">
+              <a href="http://opensuse.github.io/kiwi/" target="_blank">
                 <h4 class="media-heading opensuse-blue strong-title">
                   Kiwi
                   <small>


### PR DESCRIPTION
The previous link led to a 404 Github page. This one is working and under the openSUSE umbrella.