### PR TITLE
Update the countdown date for Leap 15.3 poo#76408

### DIFF
--- a/assets/js/countdown.js
+++ b/assets/js/countdown.js
@@ -1,7 +1,7 @@
 $(function () {
 
   // one hour later due to https://github.com/openSUSE/landing-page/issues/113
-  var leapReleaseDate = moment.tz("2020-07-02 13:00", "UTC");
+  var leapReleaseDate = moment.tz("2021-06-02 13:00", "UTC");
 
   $('.opensuse-countdown__number').countdown(leapReleaseDate.toDate(), function(event) {
 


### PR DESCRIPTION
* June 2nd 2021 is the expected date
  This might be still shifted unless we have
  confirmed GM build in both SLE and Leap