### PR TITLE
Remove outdated link to openSUSE connect

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,11 +336,6 @@
             <div class="col-xs-4">
               <ul>
                 <li>
-                  <a href="https://connect.opensuse.org/">
-                    <span lang="en">Social Network</span>
-                  </a>
-                </li>
-                <li>
                   <a href="https://news.opensuse.org/">
                     <span lang="en">News</span>
                   </a>


### PR DESCRIPTION
This services was shut off a while ago. This removes the link in the page's footer.