### PR TITLE
Revert "Revert the port addition from matrix server well-known"

### DIFF
--- a/.well-known/matrix/server/index.html
+++ b/.well-known/matrix/server/index.html
@@ -1,3 +1,3 @@
 {
-    "m.server": "matrix.opensuse.org"
+    "m.server": "matrix.opensuse.org:443"
 }


### PR DESCRIPTION
This reverts commit 0c01a383772ca4bcf7ccb76214af8644d5b6a4f1.

SRV records to indicate the matrix server port are deprecated in the matrix spec. The
matrix server runs on port 443 and only some matrix server implementations do use the srv records properly to learn this. These other implementations such as conduit.rs fail to federate because of this.