### PR TITLE
Make hamburger menu clickable in responsive view

### DIFF
--- a/assets/css/responsive-utilities.less
+++ b/assets/css/responsive-utilities.less
@@ -127,7 +127,7 @@
   .finger-detection-open-menu {
     display: block;
     position: fixed;
-    top: 0px;
+    top: 50px;
     left: 0px;
     width: 40px;
     height: 100%;


### PR DESCRIPTION
Fixes #114 
- [x] Added 50 px of top property to `.finger-detection-open-menu`.
- [x] This makes the hamburger menu clickable on mobile view.

![image](https://github.com/openSUSE/landing-page/assets/86654557/495a0e3a-c16d-4be7-a2ba-21af975c376b)