### PR TITLE
Remove .well-known

### DIFF
--- a/.well-known/matrix/client/index.html
+++ b/.well-known/matrix/client/index.html
@@ -1,6 +1,0 @@
-{
-  "m.homeserver": {
-    "base_url": "https://matrix.opensuse.org",
-    "server_name": "opensuse.org"
-  }
-}

--- a/.well-known/matrix/server/index.html
+++ b/.well-known/matrix/server/index.html
@@ -1,3 +1,0 @@
-{
-    "m.server": "matrix.opensuse.org:443"
-}


### PR DESCRIPTION
This was already configured to be served directly by our proxy servers a while ago - hence remove the no longer needed and outdated .well-known data here.